### PR TITLE
Fix variable name mismatch

### DIFF
--- a/lib/ax/application.rb
+++ b/lib/ax/application.rb
@@ -443,10 +443,10 @@ class AX::Application < AX::Element
       if AX::Application.launch id
         spin 1
       else
-        raise "#{arg} is not a registered bundle identifier for the system"
+        raise "#{id} is not a registered bundle identifier for the system"
       end
     end
-    raise "#{arg} failed to launch in time"
+    raise "#{id} failed to launch in time"
   end
 
 end


### PR DESCRIPTION
`arg` isn't defined in this method so was calling `method_missing` instead of raising the desired exception.

I should note that I am getting some test failures, but I see them in master as well so it would seem they're not related to this change.