### PR TITLE
Bump version of accessibility_core dependency to 0.7.1

### DIFF
--- a/AXElements.gemspec
+++ b/AXElements.gemspec
@@ -33,7 +33,7 @@ tools such as screen readers.
 
   s.add_runtime_dependency 'mouse',                  '~> 4.0'
   s.add_runtime_dependency 'screen_recorder',        '~> 0.1.5'
-  s.add_runtime_dependency 'accessibility_core',     '~> 0.6.1'
+  s.add_runtime_dependency 'accessibility_core',     '~> 0.7.1'
   s.add_runtime_dependency 'accessibility_keyboard', '~> 1.0'
   s.add_runtime_dependency 'activesupport',          '~> 4.2'
 end


### PR DESCRIPTION
`accessibility_core` 0.7.1 includes multiple fixes to make it work on the latest versions of macOS (otherwise native extension compilation fails).