### PR TITLE
require a version of accessibilty_core that will build on 10.12 and later

### DIFF
--- a/AXElements.gemspec
+++ b/AXElements.gemspec
@@ -33,7 +33,7 @@ tools such as screen readers.
 
   s.add_runtime_dependency 'mouse',                  '~> 4.0'
   s.add_runtime_dependency 'screen_recorder',        '~> 0.1.5'
-  s.add_runtime_dependency 'accessibility_core',     '~> 0.6.1'
+  s.add_runtime_dependency 'accessibility_core',     '~> 0.7.1'
   s.add_runtime_dependency 'accessibility_keyboard', '~> 1.0'
   s.add_runtime_dependency 'activesupport',          '~> 4.2'
 end


### PR DESCRIPTION
The current gem spec for AXElements claims a dependency on accessibility_core 0.6.1, which won't build on macOS 10.12 because of deprecation warnings. This updates the dependency to depend on 0.7.1